### PR TITLE
Update dru_fireplace.yaml

### DIFF
--- a/packages/dru_fireplace.yaml
+++ b/packages/dru_fireplace.yaml
@@ -95,9 +95,6 @@ modbus:
       - name: dru_fireplace_raw_set_temperature
         slave: 2
         address: 40250
-      - name: dru_fireplace_raw_set_temperature
-        slave: 2
-        address: 40250
 
 # Template sensors
 template:


### PR DESCRIPTION
Removed duplicate sensor: dru_fireplace_raw_set_temperature

Duplicate sensor names seem to cause a warning + repair request in recent HA.